### PR TITLE
feat: remove `rewrites` key from `firebase.json`

### DIFF
--- a/scripts/deploy_firebase_hosting
+++ b/scripts/deploy_firebase_hosting
@@ -115,6 +115,7 @@ FIREBASE_JSON
   if [ "${ENABLE_WEBFRAMEWORKS}" == "true" ]; then
     jq '.hosting.frameworksBackend = { "region": "'"${SSR_REGION}"'" }' firebase.json | sponge firebase.json
     jq 'del(.hosting.public)' firebase.json | sponge firebase.json
+    jq 'del(.hosting.rewrites)' firebase.json | sponge firebase.json
   fi
 
   log_i "firebase.json was created automatically"


### PR DESCRIPTION
Due to the following error:
- Error: Must supply a "public" or "source" directory when using "destination" rewrites.